### PR TITLE
fix: enhance CI/CD workflow by archiving and uploading lint, test, an…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -31,6 +31,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+
+      - name: Create analysis folder
+        if: always()
+        run: mkdir -p analysis
       
       - name: Run linting (flake8)
         id: lint_step
@@ -44,9 +48,7 @@ jobs:
       
       - name: Archive lint report in analysis folder
         if: always()
-        run: |
-          mkdir -p analysis
-          cp lint_output.txt analysis/lint_output.txt
+        run: cp lint_output.txt analysis/lint_output.txt
       
       - name: Upload lint report artifact
         if: always()
@@ -73,6 +75,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       
+      - name: Create analysis folder
+        if: always()
+        run: mkdir -p analysis
+      
       - name: Run tests (pytest)
         id: test_step
         continue-on-error: true
@@ -85,9 +91,7 @@ jobs:
       
       - name: Archive test report in analysis folder
         if: always()
-        run: |
-          mkdir -p analysis
-          cp test_output.txt analysis/test_output.txt
+        run: cp test_output.txt analysis/test_output.txt
       
       - name: Upload test report artifact
         if: always()
@@ -113,7 +117,6 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: 'security'
-      # Os relatórios do CodeQL podem ser acessados na aba "Security" do GitHub.
   
   bandit-scan:
     runs-on: ubuntu-latest
@@ -127,15 +130,17 @@ jobs:
           python-version: 3.11
 
       - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
+      
+      - name: Create analysis folder
+        if: always()
+        run: mkdir -p analysis
       
       - name: Run Bandit and archive report
         continue-on-error: true
         run: |
           pip install bandit
           bandit -r . > bandit_output.txt 2>&1
-          mkdir -p analysis
           cp bandit_output.txt analysis/bandit_output.txt
       
       - name: Upload Bandit report artifact

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -34,12 +34,26 @@ jobs:
       
       - name: Run linting (flake8)
         id: lint_step
+        continue-on-error: true
         run: |
           pip install flake8
           flake8 bg_remove.py > lint_output.txt 2>&1 || true
           echo "summary<<EOF" >> $GITHUB_OUTPUT
           cat lint_output.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+      
+      - name: Archive lint report in analysis folder
+        if: always()
+        run: |
+          mkdir -p analysis
+          cp lint_output.txt analysis/lint_output.txt
+      
+      - name: Upload lint report artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: analysis-lint-report
+          path: analysis/lint_output.txt
 
   test:
     runs-on: ubuntu-latest
@@ -61,12 +75,26 @@ jobs:
       
       - name: Run tests (pytest)
         id: test_step
+        continue-on-error: true
         run: |
           pip install pytest
           pytest --maxfail=1 --disable-warnings > test_output.txt 2>&1 || true
           echo "summary<<EOF" >> $GITHUB_OUTPUT
           cat test_output.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+      
+      - name: Archive test report in analysis folder
+        if: always()
+        run: |
+          mkdir -p analysis
+          cp test_output.txt analysis/test_output.txt
+      
+      - name: Upload test report artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: analysis-test-report
+          path: analysis/test_output.txt
 
   codeql:
     runs-on: ubuntu-latest
@@ -81,10 +109,12 @@ jobs:
           languages: python
       
       - name: Run CodeQL
+        continue-on-error: true
         uses: github/codeql-action/analyze@v3
         with:
           category: 'security'
-
+      # Os relatórios do CodeQL podem ser acessados na aba "Security" do GitHub.
+  
   bandit-scan:
     runs-on: ubuntu-latest
     steps:
@@ -100,7 +130,17 @@ jobs:
         run: |
           pip install -r requirements.txt
       
-      - name: Run Bandit
+      - name: Run Bandit and archive report
+        continue-on-error: true
         run: |
           pip install bandit
-          bandit -r .
+          bandit -r . > bandit_output.txt 2>&1 || true
+          mkdir -p analysis
+          cp bandit_output.txt analysis/bandit_output.txt
+      
+      - name: Upload Bandit report artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: analysis-bandit-report
+          path: analysis/bandit_output.txt

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -37,7 +37,7 @@ jobs:
         continue-on-error: true
         run: |
           pip install flake8
-          flake8 bg_remove.py > lint_output.txt 2>&1 || true
+          flake8 bg_remove.py > lint_output.txt 2>&1
           echo "summary<<EOF" >> $GITHUB_OUTPUT
           cat lint_output.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
@@ -78,7 +78,7 @@ jobs:
         continue-on-error: true
         run: |
           pip install pytest
-          pytest --maxfail=1 --disable-warnings > test_output.txt 2>&1 || true
+          pytest --maxfail=1 --disable-warnings > test_output.txt 2>&1
           echo "summary<<EOF" >> $GITHUB_OUTPUT
           cat test_output.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
@@ -134,7 +134,7 @@ jobs:
         continue-on-error: true
         run: |
           pip install bandit
-          bandit -r . > bandit_output.txt 2>&1 || true
+          bandit -r . > bandit_output.txt 2>&1
           mkdir -p analysis
           cp bandit_output.txt analysis/bandit_output.txt
       


### PR DESCRIPTION
This pull request includes several updates to the CI/CD workflow configuration in the `.github/workflows/ci-cd.yml` file. The changes primarily focus on enhancing error handling and archiving report artifacts for various steps.

Error handling improvements:

* Added `continue-on-error: true` to the linting, testing, CodeQL analysis, and Bandit scan steps to ensure the workflow continues even if these steps fail. [[1]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4R37-R57) [[2]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4R78-R98) [[3]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4R112-R116) [[4]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L103-R146)

Artifact management:

* Added steps to archive and upload linting, testing, and Bandit scan reports to an `analysis` folder and as artifacts, ensuring these reports are available even if the steps fail. [[1]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4R37-R57) [[2]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4R78-R98) [[3]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L103-R146)…d Bandit reports