### PR TITLE
fix: update upload-artifact action to version 4 in CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,7 +52,7 @@ jobs:
       
       - name: Upload lint report artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: analysis-lint-report
           path: analysis/lint_output.txt
@@ -95,7 +95,7 @@ jobs:
       
       - name: Upload test report artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: analysis-test-report
           path: analysis/test_output.txt
@@ -145,7 +145,7 @@ jobs:
       
       - name: Upload Bandit report artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: analysis-bandit-report
           path: analysis/bandit_output.txt


### PR DESCRIPTION
This pull request includes updates to the CI/CD workflow configuration file to ensure compatibility with the latest version of an action.

Updates to CI/CD workflow:

* [`.github/workflows/ci-cd.yml`](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L55-R55): Updated the `actions/upload-artifact` action from version 3 to version 4 for uploading lint, test, and Bandit report artifacts. [[1]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L55-R55) [[2]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L98-R98) [[3]](diffhunk://#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4L148-R148)