### PR TITLE
fix: add lint for flake8

### DIFF
--- a/bg_remove.py
+++ b/bg_remove.py
@@ -54,8 +54,7 @@ my_upload = st.sidebar.file_uploader(
 if my_upload is not None:
     if my_upload.size > MAX_FILE_SIZE:
         st.error(
-            "The uploaded file is too large. Please upload an image smaller "
-            "than 5MB."
+            "The uploaded file is too large. Please upload an image smaller than 5MB." # Lint error
         )
     else:
         fix_image(upload=my_upload)


### PR DESCRIPTION
This pull request includes a minor change to the `bg_remove.py` file. The change addresses a lint error by combining two lines of a string message into a single line.

* [`bg_remove.py`](diffhunk://#diff-a5ae5af256e35074d02f7dc587a338a0cb775e10c3ad676899abc7b5fe0a6532L57-R57): Combined two lines of a string message into a single line to fix a lint error in the `fix_image` function.